### PR TITLE
Add LTI course-aware flow

### DIFF
--- a/locustempus/main/tests/test_utils.py
+++ b/locustempus/main/tests/test_utils.py
@@ -1,0 +1,19 @@
+from django.core import mail
+from django.test.testcases import TestCase
+
+from locustempus.main.tests.factories import UserFactory
+from locustempus.main.utils import send_template_email
+
+
+class UtilTest(TestCase):
+
+    def test_send_template_email(self):
+        user = UserFactory()
+        with self.settings(SERVER_EMAIL='locustempus@example.com'):
+            send_template_email('foo', 'main/notify_lti_course_connect.txt',
+                                {'user': user}, 'abc123@columbia.edu')
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertEqual(mail.outbox[0].subject, 'foo')
+            self.assertEquals(mail.outbox[0].from_email,
+                              'locustempus@example.com')
+            self.assertTrue(mail.outbox[0].to, ['abc123@columbia.edu'])

--- a/locustempus/main/tests/test_views.py
+++ b/locustempus/main/tests/test_views.py
@@ -1,7 +1,16 @@
+from courseaffils.columbia import CourseStringMapper
+from courseaffils.models import Course
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.core import mail
 from django.test import TestCase
+from django.urls.base import reverse
+from lti_provider.models import LTICourseContext
+from lti_provider.tests.factories import LTICourseContextFactory
+
+
 from locustempus.main.tests.factories import (
-    CourseFactory, CourseTestMixin
-)
+    CourseFactory, CourseTestMixin, UserFactory)
 
 
 class BasicTest(TestCase):
@@ -399,3 +408,163 @@ class CourseTest(CourseTestMixin, TestCase):
             {'user_id': self.student.pk}
         )
         self.assertEqual(response.status_code, 403)
+
+
+class LTICourseSelectorTest(CourseTestMixin, TestCase):
+
+    def setUp(self):
+        self.setup_course()
+
+    def test_get(self):
+        ctx = LTICourseContextFactory(
+            group=self.course.group,
+            faculty_group=self.course.faculty_group)
+
+        url = reverse('lti-course-select', args=[ctx.lms_course_context])
+
+        self.client.login(username=self.faculty.username, password='test')
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['course'], self.course)
+
+
+class LTICourseCreateTest(TestCase):
+
+    def test_post_sis_course_id(self):
+        with self.settings(
+                COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper):
+            user = UserFactory()
+            self.client.login(username=user.username, password='test')
+
+            data = {
+                'lms_course': '1234',
+                'lms_course_title': 'LTI Course',
+                'sis_course_id': 'SOCWT7113_010_2017_3'
+            }
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+
+            c = Course.objects.get(title='LTI Course')
+            self.assertEqual(
+                c.group.name,
+                't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
+            self.assertEqual(
+                c.faculty_group.name,
+                't3.y2017.s010.ct7113.socw.fc.course:columbia.edu')
+
+            self.assertEqual(c.info.term, 3)
+            self.assertEqual(c.info.year, 2017)
+
+            self.assertTrue(user in c.group.user_set.all())
+            self.assertTrue(user in c.faculty_group.user_set.all())
+
+            self.assertEqual(len(mail.outbox), 2)
+
+            self.assertEqual(mail.outbox[0].subject,
+                             'Locus Tempus Course Connected')
+            self.assertEqual(mail.outbox[0].from_email,
+                             settings.SERVER_EMAIL)
+            self.assertEqual(mail.outbox[0].to,
+                             [settings.SERVER_EMAIL])
+
+            self.assertEqual(mail.outbox[1].subject,
+                             'Locus Tempus Course Connected')
+            self.assertEqual(mail.outbox[1].from_email,
+                             settings.SERVER_EMAIL)
+            self.assertEqual(mail.outbox[1].to,
+                             [user.email])
+
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
+
+            # try this again and make sure there is no duplication
+            data['lms_course_title'] = 'LTI Course With More Detail'
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+            Course.objects.get(title='LTI Course')
+            Group.objects.get(name=c.group.name)
+            Group.objects.get(name=c.faculty_group.name)
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
+
+    def test_post_course_context(self):
+        with self.settings(
+                COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper):
+
+            user = UserFactory()
+            self.client.login(username=user.username, password='test')
+
+            data = {
+                'lms_course': '1234',
+                'lms_course_title': 'LTI Course',
+                'sis_course_id': '20170152049'
+            }
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+
+            c = Course.objects.get(title='LTI Course')
+            self.assertEqual(c.group.name, '1234')
+            self.assertEqual(c.faculty_group.name, '1234_faculty')
+            self.assertEqual(c.info.term, 1)
+            self.assertEqual(c.info.year, 2017)
+
+            self.assertTrue(user in c.group.user_set.all())
+            self.assertTrue(user in c.faculty_group.user_set.all())
+
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
+
+            # try this again and make sure there is no duplication
+            data['lms_course_title'] = 'LTI Course With More Detail'
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+            Course.objects.get(title='LTI Course')
+            Group.objects.get(name=c.group.name)
+            Group.objects.get(name=c.faculty_group.name)
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
+
+    def test_post_course_context_with_unicode(self):
+        with self.settings(
+                COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper):
+
+            user = UserFactory()
+            self.client.login(username=user.username, password='test')
+
+            data = {
+                'lms_course': '1234',
+                'lms_course_title': 'LTI Course "Película", rødgrød med fløde',
+                'sis_course_id': '20170152049'
+            }
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+
+            c = Course.objects.get(
+                title='LTI Course "Película", rødgrød med fløde')
+            self.assertEqual(c.group.name, '1234')
+            self.assertEqual(c.faculty_group.name, '1234_faculty')
+            self.assertEqual(c.info.term, 1)
+            self.assertEqual(c.info.year, 2017)
+
+            self.assertTrue(user in c.group.user_set.all())
+            self.assertTrue(user in c.faculty_group.user_set.all())
+
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
+
+            # try this again and make sure there is no duplication
+            data['lms_course_title'] = 'LTI Course With More Detail'
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+            Course.objects.get(
+                title='LTI Course "Película", rødgrød med fløde')
+            Group.objects.get(name=c.group.name)
+            Group.objects.get(name=c.faculty_group.name)
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)

--- a/locustempus/main/utils.py
+++ b/locustempus/main/utils.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.core.mail import send_mail
+from django.core.validators import validate_email
+from django.template import loader
+
+
+def send_template_email(subject, template_name, params, recipient):
+    validate_email(recipient)
+
+    template = loader.get_template(template_name)
+    message = template.render(params)
+    send_mail(subject, message, settings.SERVER_EMAIL, [recipient])

--- a/locustempus/main/views.py
+++ b/locustempus/main/views.py
@@ -1,17 +1,25 @@
+import re
+
+from courseaffils.columbia import WindTemplate, CanvasTemplate
 from courseaffils.models import Course
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import (
     LoginRequiredMixin
 )
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
-from django.views.generic.base import TemplateView
+from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
+from lti_provider.models import LTICourseContext
 
+from locustempus.main.utils import send_template_email
 from locustempus.mixins import (
     LoggedInCourseMixin, LoggedInFacultyMixin, LoggedInSuperuserMixin
 )
@@ -94,3 +102,110 @@ class CourseRosterView(LoggedInFacultyMixin, DetailView):
         messages.add_message(request, messages.INFO, msg)
         return HttpResponseRedirect(
             reverse('course-roster-view', args=[course.pk]))
+
+
+@method_decorator(xframe_options_exempt, name='dispatch')
+class LTICourseCreate(LoginRequiredMixin, View):
+
+    def notify_staff(self, course):
+        data = {
+            'course': course,
+            'domain': self.request.POST.get('domain'),
+            'user': self.request.user
+        }
+        send_template_email(
+            'Locus Tempus Course Connected',
+            'main/notify_lti_course_connect.txt',
+            data, settings.SERVER_EMAIL)
+
+    def thank_faculty(self, course):
+        send_template_email(
+            'Locus Tempus Course Connected',
+            'main/lti_course_connect.txt',
+            {'course': course}, self.request.user.email)
+
+    def groups_from_context(self, course_context):
+        group, created = Group.objects.get_or_create(name=course_context)
+        faculty_group, created = Group.objects.get_or_create(
+            name='{}_faculty'.format(course_context))
+        return (group, faculty_group)
+
+    def groups_from_sis_course_id(self, attrs):
+        st_affil = WindTemplate.to_string(attrs)
+        group, created = Group.objects.get_or_create(name=st_affil)
+        self.request.user.groups.add(group)
+
+        attrs['member'] = 'fc'
+        fc_affil = WindTemplate.to_string(attrs)
+        faculty_group, created = Group.objects.get_or_create(name=fc_affil)
+        self.request.user.groups.add(faculty_group)
+        return (group, faculty_group)
+
+    def get_year_and_term_from_sis_course_id(self, sis_course_id):
+        m = re.match(
+            (r'(?P<year>\d{4})(?P<term>\d{2})'), sis_course_id)
+        if m:
+            return m.groupdict()
+
+    def post(self, *args, **kwargs):
+        course_context = self.request.POST.get('lms_course')
+        title = self.request.POST.get('lms_course_title')
+
+        sis_course_id = self.request.POST.get('sis_course_id', '')
+        d = CanvasTemplate.to_dict(sis_course_id)
+
+        if d:
+            (group, faculty_group) = self.groups_from_sis_course_id(d)
+        else:
+            (group, faculty_group) = self.groups_from_context(course_context)
+            yt = self.get_year_and_term_from_sis_course_id(sis_course_id)
+
+        self.request.user.groups.add(group)
+        self.request.user.groups.add(faculty_group)
+
+        course, created = Course.objects.get_or_create(
+            group=group, faculty_group=faculty_group,
+            defaults={'title': title})
+
+        if d:
+            # Add CourseInfo from the fields
+            course.info.term = d['term']
+            course.info.year = d['year']
+            course.info.save()
+        elif yt:
+            course.info.term = yt['term']
+            course.info.year = yt['year']
+            course.info.save()
+
+        # hook up the context
+        (ctx, created) = LTICourseContext.objects.get_or_create(
+            group=group, faculty_group=faculty_group,
+            lms_course_context=course_context)
+
+        messages.add_message(
+            self.request, messages.INFO,
+            u'<strong>Success!</strong> ' +
+            u'{} is connected to Locus Tempus.'.format(title))
+
+        self.notify_staff(course)
+        self.thank_faculty(course)
+
+        url = reverse('lti-landing-page')
+        return HttpResponseRedirect(url)
+
+
+class LTICourseSelector(LoginRequiredMixin, View):
+
+    def get(self, request, context):
+        try:
+            messages.add_message(
+                request, messages.INFO,
+                'Reminder: please log out of Locus Tempus '
+                'after you log out of Courseworks.')
+
+            ctx = LTICourseContext.objects.get(lms_course_context=context)
+            url = u'/course/{}/'.format(ctx.group.course.id)
+        except LTICourseContext.DoesNotExist:
+            url = '/'
+
+        return HttpResponseRedirect(url)

--- a/locustempus/settings_shared.py
+++ b/locustempus/settings_shared.py
@@ -41,10 +41,10 @@ LTI_TOOL_CONFIGURATION = {
     'embed_url': '',
     'embed_icon_url': '',
     'embed_tool_id': '',
-    'landing_url': '{}://{}/',
+    'landing_url': '{}://{}/course/lti/{}/',
     'course_aware': True,
     'navigation': True,
-    'new_tab': False,
+    'new_tab': True,
     'frame_width': 1024,
     'frame_height': 1024
 }

--- a/locustempus/templates/lti_provider/fail_course_configuration.html
+++ b/locustempus/templates/lti_provider/fail_course_configuration.html
@@ -1,0 +1,35 @@
+{% load coursetags static %}
+{% get_instructor_courses user as courses %}
+<html>
+    <head>
+        <title>Course Configuration</title>
+    </head>
+    <body>
+         {% if not is_instructor and not is_administrator %}
+            <div>
+                <p>
+                    Your {{title}} course has not been configured to use this component.<br />
+                    Contact your instructor for more information.
+                </p>
+            </div>
+         {% else %}
+            <div>
+                <p>
+                    Locus Tempus is an open-source platform for exploration, analysis, and organization of location-based content.
+                </p>
+                <p>
+                    Connect your Canvas course to Locus Tempus.
+                </p>
+                <form class="text-center" action="{% url 'lti-course-create' %}" method='POST'>
+                    <input type="hidden" name="lms_course" value="{{lms_course}}">
+                    <input type="hidden" name="lms_course_title" value="{{lms_course_title}}">
+                    <input type="hidden" name="sis_course_id" value="{{sis_course_id}}">
+                    <input type="hidden" name="domain" value="{{domain}}">
+                    <p>
+                        <button type="submit" class="btn btn-primary btn-lg">Connect Now</button>
+                    </p>
+                </form>
+            </div>
+        {% endif %}
+    </body>
+</html>

--- a/locustempus/templates/main/lti_course_connect.txt
+++ b/locustempus/templates/main/lti_course_connect.txt
@@ -4,7 +4,7 @@ You have successfully created a new Locus Tempus site for {{course.title}}.
 
 The Center for Teaching and Learning (CTL) offers instructors a range of support for using Locus Tempus effectively.
 
-CTL learning designers can help you conceptualize and set up projects in Locus Tempus. We are also happy to offer in-person training sessions for your class. Please email us at ccnmtl-locustempus@columbia.edu to request a consultation or training.
+CTL learning designers can help you conceptualize and set up projects in Locus Tempus. We are also happy to offer in-person training sessions for your class. Please email us at ctl-locustempus@columbia.edu to request a consultation or training.
 
 Locus Tempus is designed and maintained here at the CTL, and we are always eager to receive ideas from the Columbia community – please let us know how it goes! We hope you have a successful semester using Locus Tempus.
 

--- a/locustempus/templates/main/lti_course_connect.txt
+++ b/locustempus/templates/main/lti_course_connect.txt
@@ -1,0 +1,14 @@
+Dear colleague,
+
+You have successfully created a new Locus Tempus site for {{course.title}}.
+
+The Center for Teaching and Learning (CTL) offers instructors a range of support for using Locus Tempus effectively.
+
+CTL learning designers can help you conceptualize and set up projects in Locus Tempus. We are also happy to offer in-person training sessions for your class. Please email us at ccnmtl-locustempus@columbia.edu to request a consultation or training.
+
+Locus Tempus is designed and maintained here at the CTL, and we are always eager to receive ideas from the Columbia community – please let us know how it goes! We hope you have a successful semester using Locus Tempus.
+
+
+Thanks,
+The Locus Tempus Staff
+

--- a/locustempus/templates/main/notify_lti_course_connect.txt
+++ b/locustempus/templates/main/notify_lti_course_connect.txt
@@ -1,0 +1,9 @@
+{{user.get_full_name}} has connected a Canvas course to Locus Tempus.
+
+Username: {{user.username}}
+
+Email: {{user.email}}
+
+Course Title: {{course.title}} {{course.info.term}} {{course.info.year}}
+
+Canvas Domain: {{domain}}

--- a/locustempus/urls.py
+++ b/locustempus/urls.py
@@ -1,9 +1,11 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.conf import settings
 from django.views.generic import TemplateView
 from django.views.static import serve
+
 from locustempus.main import views
+
 
 admin.autodiscover()
 
@@ -17,6 +19,10 @@ urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='course-list-view'),
     url(r'^admin/', admin.site.urls),
     url(r'^lti/', include('lti_provider.urls')),
+    url(r'^course/lti/create/$',
+        views.LTICourseCreate.as_view(), name='lti-course-create'),
+    url(r'^course/lti/(?P<context>\w[^/]*)/$',
+        views.LTICourseSelector.as_view(), name='lti-course-select'),
     url(r'^_impersonate/', include('impersonate.urls')),
     url(r'^stats/$$', TemplateView.as_view(template_name='stats.html')),
     url(r'smoketest/', include('smoketest.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ oauth2==1.9.0.post1
 oauthlib==3.1.0
 httplib2==0.17.0
 pylti==0.7.0
-django-lti-provider==0.3.4
+django-lti-provider==0.4.0
 
 pyparsing==2.4.6
 edtf==4.0.1 # pyup: <4.0.0


### PR DESCRIPTION
Leverage `courseaffils` library + `django-lti-provider` library to create a course-aware flow for Locus Tempus. LT courses can automatically be created by instructors within an LMS. And, instructors and students are automatically provisioned in the course when they interact with a Locus Tempus LTI component.