### PR TITLE
Non Atomic migration

### DIFF
--- a/locustempus/main/migrations/0009_auto_20200715_1057.py
+++ b/locustempus/main/migrations/0009_auto_20200715_1057.py
@@ -6,6 +6,7 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),


### PR DESCRIPTION
The last migration uses features of transactions that are not supported
in SQLite. To bypass this in our testing environment, this makes the
migration non-atomic.