### PR TITLE
Bugfix: Project title rename

### DIFF
--- a/locustempus/main/serializers.py
+++ b/locustempus/main/serializers.py
@@ -15,6 +15,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Project
+        read_only_fields = ('activity',)
         fields = (
             'title', 'description', 'base_map', 'layers', 'activity'
         )


### PR DESCRIPTION
This commit fixes a bug where Project titles could not be renamed
because the DRF serializer was expecting the project activity to be
present in the POST request. This fixes the issue by making the field
read-only.