### PR TITLE
Activity/Response Layers

### DIFF
--- a/locustempus/main/serializers.py
+++ b/locustempus/main/serializers.py
@@ -36,20 +36,15 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
         many=True,
         view_name='api-layer-detail'
     )
-    activity = ActivitySerializer()
+    activity = serializers.PrimaryKeyRelatedField(
+        queryset=Activity.objects.all())
 
     def create(self, validated_data):
-        try:
-            a = Activity.objects.get(
-                pk=validated_data.get('activity', None)
-            )
-
-            r = Response.objects.create(activity=a)
-            ResponseOwner(
-                response=r, owner=self.context['request'].user, activity=a)
-            return r
-        except Activity.DoesNotExist:
-            pass
+        a = validated_data.get('activity')
+        r = Response.objects.create(activity=a)
+        ResponseOwner.objects.create(
+            response=r, owner=self.context['request'].user, activity=a)
+        return r
 
     class Meta:
         model = Response

--- a/locustempus/main/serializers.py
+++ b/locustempus/main/serializers.py
@@ -48,9 +48,9 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Response
-        read_only_fields = ('layers',)
+        read_only_fields = ('layers', 'pk')
         fields = (
-            'activity', 'layers'
+            'pk', 'activity', 'layers'
         )
 
 

--- a/locustempus/main/serializers.py
+++ b/locustempus/main/serializers.py
@@ -31,13 +31,16 @@ class ActivitySerializer(serializers.ModelSerializer):
 
 
 class ResponseSerializer(serializers.HyperlinkedModelSerializer):
-    layers = serializers.PrimaryKeyRelatedField(
-        many=True, queryset=Layer.objects.all())
+    layers = serializers.HyperlinkedRelatedField(
+        read_only=True,
+        many=True,
+        view_name='api-layer-detail'
+    )
 
     class Meta:
         model = Response
         fields = (
-            'activity', 'layer'
+            'layers',
         )
 
 

--- a/locustempus/main/tests/factories.py
+++ b/locustempus/main/tests/factories.py
@@ -122,5 +122,8 @@ class CourseTestMixin(object):
         self.sandbox_course.group.user_set.add(self.faculty)
         self.sandbox_course.faculty_group.user_set.add(self.faculty)
         p2 = ProjectFactory.create(course=self.sandbox_course)
+        self.sandbox_course_project = p2
         a2 = ActivityFactory.create(project=p2)
-        ResponseFactory.create(activity=a2, owners=[self.student])
+        self.sandbox_course_activity = a2
+        self.sandbox_course_response = ResponseFactory.create(
+            activity=a2, owners=[self.student])

--- a/locustempus/main/tests/test_viewsets.py
+++ b/locustempus/main/tests/test_viewsets.py
@@ -5,7 +5,7 @@ from locustempus.main.permissions import (
     IsLoggedInCourse, IsLoggedInFaculty
 )
 from locustempus.main.tests.factories import (
-    CourseTestMixin, UserFactory
+    CourseTestMixin, UserFactory, ProjectFactory, ActivityFactory
 )
 from unittest.mock import MagicMock
 
@@ -266,12 +266,15 @@ class ResponseAPITest(CourseTestMixin, TestCase):
                 password='test'
             )
         )
+        p = ProjectFactory.create(course=self.sandbox_course)
+        a = ActivityFactory.create(project=p)
         response = self.client.post(
             reverse('api-response-list'),
             {
-                'activity': self.sandbox_course_activity.pk,
+                'activity': a.pk,
             }
         )
+        self.assertEqual(response.status_code, 201)
 
     def test_activity_response_querystring(self):
         self.assertTrue(

--- a/locustempus/main/tests/test_viewsets.py
+++ b/locustempus/main/tests/test_viewsets.py
@@ -259,6 +259,20 @@ class ResponseAPITest(CourseTestMixin, TestCase):
     def setUp(self):
         self.setup_course()
 
+    def create_student_response(self):
+        self.assertTrue(
+            self.client.login(
+                username=self.student.username,
+                password='test'
+            )
+        )
+        response = self.client.post(
+            reverse('api-response-list'),
+            {
+                'activity': self.sandbox_course_activity.pk,
+            }
+        )
+
     def test_activity_response_querystring(self):
         self.assertTrue(
             self.client.login(

--- a/locustempus/main/tests/test_viewsets.py
+++ b/locustempus/main/tests/test_viewsets.py
@@ -259,7 +259,7 @@ class ResponseAPITest(CourseTestMixin, TestCase):
     def setUp(self):
         self.setup_course()
 
-    def create_student_response(self):
+    def test_create_student_response(self):
         self.assertTrue(
             self.client.login(
                 username=self.student.username,
@@ -285,8 +285,8 @@ class ResponseAPITest(CourseTestMixin, TestCase):
         )
 
         response = self.client.get(
-            reverse('api-response-list') + '?activity={}&owner={}'.format(
-                self.sandbox_course_activity.pk, self.student.pk
+            reverse('api-response-list') + '?activity={}'.format(
+                self.sandbox_course_activity.pk
             )
         )
 

--- a/locustempus/main/tests/test_viewsets.py
+++ b/locustempus/main/tests/test_viewsets.py
@@ -253,3 +253,24 @@ class LayerAPITest(CourseTestMixin, TestCase):
             reverse('api-layer-detail', args=[layer.pk])
         )
         self.assertEqual(response.status_code, 204)
+
+
+class ResponseAPITest(CourseTestMixin, TestCase):
+    def setUp(self):
+        self.setup_course()
+
+    def test_activity_response_querystring(self):
+        self.assertTrue(
+            self.client.login(
+                username=self.student.username,
+                password='test'
+            )
+        )
+
+        response = self.client.get(
+            reverse('api-response-list') + '?activity={}&owner={}'.format(
+                self.sandbox_course_activity.pk, self.student.pk
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/locustempus/main/viewsets.py
+++ b/locustempus/main/viewsets.py
@@ -1,6 +1,8 @@
 """The viewsets and views used for the API"""
 from django.contrib.auth.models import User
-from locustempus.main.models import Layer, Project, Event, Activity, Response
+from locustempus.main.models import (
+    Layer, Project, Event, Activity, Response
+)
 from locustempus.main.permissions import IsLoggedInCourse
 from locustempus.main.serializers import (
     LayerSerializer, ProjectSerializer, EventSerializer, ActivitySerializer,

--- a/locustempus/main/viewsets.py
+++ b/locustempus/main/viewsets.py
@@ -8,7 +8,7 @@ from locustempus.main.serializers import (
     LayerSerializer, ProjectSerializer, EventSerializer, ActivitySerializer,
     ResponseSerializer
 )
-from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from rest_framework.viewsets import ModelViewSet
 
 
 class ProjectApiView(ModelViewSet):

--- a/locustempus/main/viewsets.py
+++ b/locustempus/main/viewsets.py
@@ -43,21 +43,18 @@ class ResponseApiView(ModelViewSet):
     def get_queryset(self):
         qs = Response.objects.all()
 
-        try:
-            activity = Activity.objects.get(
-                pk=self.request.query_params.get('activity', None)
-            )
-
-            owner = User.objects.get(
-                pk=self.request.query_params.get('owner', None)
-            )
-
-            if activity and owner:
-                qs = Response.objects.filter(
-                    activity=activity,
-                    owners__in=[owner]
-                )
-        except (Activity.DoesNotExist, User.DoesNotExist):
-            pass
+        activity_qs = self.request.query_params.get('activity', None)
+        owner_qs = self.request.query_params.get('owner', None)
+        if activity_qs and owner_qs:
+            try:
+                activity = Activity.objects.get(pk=activity_qs)
+                owner = User.objects.get(pk=owner_qs)
+                if activity and owner:
+                    qs = Response.objects.filter(
+                        activity=activity,
+                        owners__in=[owner]
+                    )
+            except (Activity.DoesNotExist, User.DoesNotExist):
+                return []
 
         return qs

--- a/locustempus/urls.py
+++ b/locustempus/urls.py
@@ -18,6 +18,7 @@ if hasattr(settings, 'CAS_BASE'):
 router = routers.DefaultRouter()
 router.register(r'project', viewsets.ProjectApiView, basename='api-project')
 router.register(r'activity', viewsets.ActivityApiView, basename='api-activity')
+router.register(r'response', viewsets.ResponseApiView, basename='api-response')
 router.register(r'layer', viewsets.LayerApiView, basename='api-layer')
 router.register(r'event', viewsets.EventApiView, basename='api-event')
 

--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -493,7 +493,7 @@ export const ActivityMap: React.FC = () => {
             // If a contributor, get or create a response
             if (activityPk && CURRENT_USER) {
                 const resp = await fetch(
-                    `/api/response/?activity=${activityPk}&owner=${CURRENT_USER}`);
+                    `/api/response/?activity=${activityPk}`);
                 if (!resp.ok) {
                     throw new Error('Project response request failed.');
                 }

--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -302,9 +302,16 @@ export const ActivityMap: React.FC = () => {
         }
     };
 
+    const isProjectLayer = (pk: number): boolean => {
+        return projectEventData.has(pk);
+    };
+
     const setLayerVisibility = (pk: number): void => {
-        // TODO: make this work with Project layers
-        const updatedEvents = new Map(eventData);
+        const isProj = isProjectLayer(pk);
+        const data = isProj ? projectEventData : eventData;
+        const updateFunc = isProj ? updateProjectEventData : updateEventData;
+
+        const updatedEvents = new Map(data);
         const layerEvents = updatedEvents.get(pk);
 
         if (layerEvents) {
@@ -313,7 +320,7 @@ export const ActivityMap: React.FC = () => {
                 events: layerEvents.events
             });
 
-            updateEventData(updatedEvents);
+            updateFunc(updatedEvents);
         }
     };
 
@@ -621,6 +628,7 @@ export const ActivityMap: React.FC = () => {
                     setLayerVisibility={setLayerVisibility}
                     projectLayers={projectLayerData}
                     projectEvents={projectEventData}
+                    isProjectLayer={isProjectLayer}
                     showAddEventForm={showAddEventForm}
                     setShowAddEventForm={setShowAddEventForm}
                     activePosition={activePosition}

--- a/media/src/activity/project-map-pane-panels.tsx
+++ b/media/src/activity/project-map-pane-panels.tsx
@@ -479,6 +479,8 @@ interface DefaultPanelProps {
     description: string;
     layers: LayerProps[];
     events: Map<number, LayerEventData>;
+    projectLayers: LayerProps[];
+    projectEvents: Map<number, LayerEventData>;
     activity: ActivityData | null;
     deleteLayer(pk: number): void;
     updateLayer(pk: number, title: string): void;
@@ -498,7 +500,7 @@ export const DefaultPanel: React.FC<DefaultPanelProps> = (
         activeTab, setActiveTab, addLayer, description, layers, events,
         activity, deleteLayer, updateLayer, setLayerVisibility, activeLayer,
         setActiveLayer, activeEvent, setActiveEvent, setActiveEventDetail,
-        activeEventEdit
+        activeEventEdit, projectLayers, projectEvents
     }: DefaultPanelProps) => {
 
     const handleSetActiveTab = (
@@ -544,13 +546,9 @@ export const DefaultPanel: React.FC<DefaultPanelProps> = (
                 )}
                 {activeTab === BASE && (
                     <div className='fade-load'>
-                        {/* TODO: Implement a read-only layer for project events */}
                         <LayerSet
-                            layers={layers}
-                            events={events}
-                            addLayer={addLayer}
-                            deleteLayer={deleteLayer}
-                            updateLayer={updateLayer}
+                            layers={projectLayers}
+                            events={projectEvents}
                             setLayerVisibility={setLayerVisibility}
                             activeLayer={activeLayer}
                             setActiveLayer={setActiveLayer}

--- a/media/src/activity/project-map-pane-panels.tsx
+++ b/media/src/activity/project-map-pane-panels.tsx
@@ -328,7 +328,7 @@ export const EventAddPanel: React.FC<EventAddPanelProps> = (
                 eventName === '' ? 'Untitled Marker' : eventName,
                 description, activePosition[0], activePosition[1]);
             setShowAddEventForm(false);
-            setActiveTab(1);
+            setActiveTab(2);
             clearActivePosition();
         }
     };

--- a/media/src/activity/project-map-pane-panels.tsx
+++ b/media/src/activity/project-map-pane-panels.tsx
@@ -406,15 +406,15 @@ interface EventDetailPanelProps {
     activeLayer: number | null;
     activeEventDetail: LayerEventDatum | null;
     setActiveEventDetail(d: LayerEventDatum | null): void;
-    activeEventEdit: LayerEventDatum | null;
     setActiveEventEdit(d: LayerEventDatum | null): void;
     deleteEvent(pk: number, layerPk: number): void;
+    isProjectLayer(pk: number): boolean;
 }
 
 export const EventDetailPanel: React.FC<EventDetailPanelProps> = (
     {
         activeLayer, activeEventDetail, setActiveEventDetail,
-        setActiveEventEdit, deleteEvent
+        setActiveEventEdit, deleteEvent, isProjectLayer
     }: EventDetailPanelProps) => {
     const [showMenu, setShowMenu] = useState<boolean>(false);
 
@@ -447,9 +447,11 @@ export const EventDetailPanel: React.FC<EventDetailPanelProps> = (
                 <button onClick={handleBack}>
                     <FontAwesomeIcon icon={faArrowLeft}/> Back
                 </button>
-                <button onClick={handleMenuToggle}>
-                    <FontAwesomeIcon icon={faEllipsisV}/>
-                </button>
+                {activeLayer && !isProjectLayer(activeLayer) && (
+                    <button onClick={handleMenuToggle}>
+                        <FontAwesomeIcon icon={faEllipsisV}/>
+                    </button>
+                )}
             </div>
             {showMenu && (
                 <div>

--- a/media/src/activity/project-map-pane.tsx
+++ b/media/src/activity/project-map-pane.tsx
@@ -12,6 +12,8 @@ export interface ProjectMapPaneProps {
     description: string;
     layers: LayerProps[];
     events: Map<number, LayerEventData>;
+    projectLayers: LayerProps[];
+    projectEvents: Map<number, LayerEventData>;
     activity: ActivityData | null;
     activeLayer: number | null;
     setActiveLayer(pk: number): void;
@@ -43,7 +45,7 @@ export const ProjectMapPane: React.FC<ProjectMapPaneProps> = (
         showAddEventForm, setShowAddEventForm, activePosition, addEvent,
         clearActivePosition, activeEvent, setActiveEvent, activeEventDetail,
         setActiveEventDetail, activeEventEdit, setActiveEventEdit, deleteEvent,
-        updateEvent
+        updateEvent, projectLayers, projectEvents
     }: ProjectMapPaneProps) => {
 
     const [activeTab, setActiveTab] = useState<number>(0);
@@ -93,6 +95,8 @@ export const ProjectMapPane: React.FC<ProjectMapPaneProps> = (
             description={description}
             layers={layers}
             events={events}
+            projectLayers={projectLayers}
+            projectEvents={projectEvents}
             activity={activity}
             deleteLayer={deleteLayer}
             updateLayer={updateLayer}

--- a/media/src/activity/project-map-pane.tsx
+++ b/media/src/activity/project-map-pane.tsx
@@ -21,6 +21,7 @@ export interface ProjectMapPaneProps {
     deleteLayer(pk: number): void;
     updateLayer(pk: number, title: string): void;
     setLayerVisibility(pk: number): void;
+    isProjectLayer(pk: number): boolean;
     showAddEventForm: boolean;
     setShowAddEventForm(val: boolean): void;
     activePosition: Position | null;
@@ -42,10 +43,11 @@ export const ProjectMapPane: React.FC<ProjectMapPaneProps> = (
     {
         title, description, layers, events, activity, activeLayer,
         setActiveLayer, addLayer, deleteLayer, updateLayer, setLayerVisibility,
-        showAddEventForm, setShowAddEventForm, activePosition, addEvent,
-        clearActivePosition, activeEvent, setActiveEvent, activeEventDetail,
-        setActiveEventDetail, activeEventEdit, setActiveEventEdit, deleteEvent,
-        updateEvent, projectLayers, projectEvents
+        isProjectLayer, showAddEventForm, setShowAddEventForm, activePosition,
+        addEvent, clearActivePosition, activeEvent, setActiveEvent,
+        activeEventDetail, setActiveEventDetail, activeEventEdit,
+        setActiveEventEdit, deleteEvent, updateEvent, projectLayers,
+        projectEvents
     }: ProjectMapPaneProps) => {
 
     const [activeTab, setActiveTab] = useState<number>(0);
@@ -78,9 +80,9 @@ export const ProjectMapPane: React.FC<ProjectMapPaneProps> = (
             activeLayer={activeLayer}
             activeEventDetail={activeEventDetail}
             setActiveEventDetail={setActiveEventDetail}
-            activeEventEdit={activeEventEdit}
             setActiveEventEdit={setActiveEventEdit}
-            deleteEvent={deleteEvent}/>,
+            deleteEvent={deleteEvent}
+            isProjectLayer={isProjectLayer}/>,
         2: <> {activeEventEdit && (
             <EventEditPanel
                 activeLayer={activeLayer}

--- a/media/src/project-activity-components/layers/layer-set.tsx
+++ b/media/src/project-activity-components/layers/layer-set.tsx
@@ -26,9 +26,9 @@ export interface LayerEventData {
 interface LayerSetProps {
     layers: LayerProps[];
     events: Map<number, LayerEventData>;
-    addLayer(): void;
-    deleteLayer(pk: number): void;
-    updateLayer(pk: number, title: string): void;
+    addLayer?(): void;
+    deleteLayer?(pk: number): void;
+    updateLayer?(pk: number, title: string): void;
     setLayerVisibility(pk: number): void;
     activeLayer: number | null;
     setActiveLayer(pk: number): void;
@@ -47,16 +47,20 @@ export const LayerSet: React.FC<LayerSetProps> = (
 
     const handleCreateLayer = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
-        addLayer();
+        if (addLayer) {
+            addLayer();
+        }
     };
 
     return (
         <>
-            <form onSubmit={handleCreateLayer}>
-                <button type='submit'>
-                    <FontAwesomeIcon icon={faLayerGroup}/>Add Layer
-                </button>
-            </form>
+            {addLayer && (
+                <form onSubmit={handleCreateLayer}>
+                    <button type='submit'>
+                        <FontAwesomeIcon icon={faLayerGroup}/>Add Layer
+                    </button>
+                </form>
+            )}
             {layers && layers.map(
                 (layer, idx) => {
                     let layerEvents: LayerEventDatum[] = [];

--- a/media/src/project-activity-components/layers/layer.tsx
+++ b/media/src/project-activity-components/layers/layer.tsx
@@ -11,8 +11,8 @@ export interface LayerProps {
     activeLayer: number | null;
     layerEvents: LayerEventDatum[];
     setActiveLayer(pk: number): void;
-    deleteLayer(pk: number): void;
-    updateLayer(pk: number, title: string): void;
+    deleteLayer?(pk: number): void;
+    updateLayer?(pk: number, title: string): void;
     layerVisibility: boolean;
     setLayerVisibility(pk: number): void;
     activeEvent: LayerEventDatum | null;
@@ -37,12 +37,16 @@ export const Layer: React.FC<LayerProps> = (
 
     const handleUpdateLayer = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
-        updateLayer(pk, updatedLayerTitle);
+        if (updateLayer) {
+            updateLayer(pk, updatedLayerTitle);
+        }
     };
 
     const handleDeleteLayer = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
-        deleteLayer(pk);
+        if (deleteLayer) {
+            deleteLayer(pk);
+        }
     };
 
     const handleSetActiveLayer = (): void => {
@@ -82,13 +86,15 @@ export const Layer: React.FC<LayerProps> = (
                 </button>
                 <span id={'sidebar-layer-infobar__title'}
                     className="font-weight-bold">{title}</span>
-                <button
-                    id={'sidebar-layer-infobar__menu-btn'}
-                    onClick={handleLayerMenu}>
-                    <FontAwesomeIcon icon={faEllipsisV}/>
-                </button>
+                { updateLayer && deleteLayer && (
+                    <button
+                        id={'sidebar-layer-infobar__menu-btn'}
+                        onClick={handleLayerMenu}>
+                        <FontAwesomeIcon icon={faEllipsisV}/>
+                    </button>
+                )}
             </div>
-            { openLayerMenu && (
+            { openLayerMenu && updateLayer && deleteLayer && (
                 <div id={'sidebar-layer-infobar__menu'}>
                     <form onSubmit={handleUpdateLayer}>
                         <label>Layer Title:


### PR DESCRIPTION
- Implement querystring params for response lookup
- Implement Response creation API endpoint
- Refactor, actually make the tests pass
- Adjust DRF endpoints for front-end work
- Implement Layers in Activity/Response space
- Flake8 fix
- Bug: set correct tab after event creation
