### PR TITLE
Refactor DeckGL layer aggregation, fix event creation bug

### DIFF
--- a/media/src/activity/activity-map-pane.tsx
+++ b/media/src/activity/activity-map-pane.tsx
@@ -37,12 +37,11 @@ export interface ActivityMapPaneProps {
     toggleResponseVisibility(pk: number): void;
     isProjectLayer(pk: number): boolean;
     showAddEventForm: boolean;
-    setShowAddEventForm(val: boolean): void;
+    displayAddEventForm(show: boolean, mockData?: EventData): void;
     activePosition: Position | null;
     addEvent(label: string,
              description: string, lat: number, lng: number, mediaObj: MediaObject | null): void;
     deleteEvent(pk: number, layerPk: number): void;
-    clearActivePosition(): void;
     activeEvent: EventData | null;
     setActiveEvent(d: EventData): void;
     activeEventDetail: EventData | null;
@@ -66,8 +65,8 @@ export const ActivityMapPane = React.forwardRef<HTMLDivElement, ActivityMapPaneP
         activeLayer, setActiveLayer, addLayer, deleteLayer,
         updateLayer,layerVisibility, toggleLayerVisibility,
         toggleResponseVisibility, isProjectLayer, showAddEventForm,
-        setShowAddEventForm, activePosition, addEvent, clearActivePosition,
-        activeEvent, setActiveEvent, activeEventDetail, setActiveEventDetail,
+        displayAddEventForm, activePosition, addEvent, activeEvent,
+        setActiveEvent, activeEventDetail, setActiveEventDetail,
         activeEventEdit, setActiveEventEdit, deleteEvent, updateEvent,
         projectLayers, responseData, updateResponse, createFeedback,
         updateFeedback, responseLayers
@@ -137,10 +136,9 @@ export const ActivityMapPane = React.forwardRef<HTMLDivElement, ActivityMapPaneP
     const PANEL: {[key: number]: ReactElement} = {
         0: <EventAddPanel
             showAddEventForm={showAddEventForm}
-            setShowAddEventForm={setShowAddEventForm}
+            displayAddEventForm={displayAddEventForm}
             activePosition={activePosition}
             addEvent={addEvent}
-            clearActivePosition={clearActivePosition}
             setActiveTab={setActiveTab}
             activeLayer={activeLayer}
             layers={layers}

--- a/media/src/project-activity-components/panels/event-add-panel.tsx
+++ b/media/src/project-activity-components/panels/event-add-panel.tsx
@@ -3,26 +3,25 @@ import { Position } from '@deck.gl/core/utils/positions';
 import { MediaEditor } from '../layers/media-editor';
 import { MediaObject } from '../common';
 import ReactQuill from 'react-quill';
-import { LayerData } from '../common';
+import { EventData, LayerData } from '../common';
 
 interface EventAddPanelProps {
     showAddEventForm: boolean;
-    setShowAddEventForm(val: boolean): void;
+    displayAddEventForm(show: boolean, mockData?: EventData): void;
     activePosition: Position | null;
     layers: Map<number, LayerData>;
     activeLayer: number | null;
     addEvent(
         label: string, description: string, lat: number, lng: number,
         mediaObj: MediaObject | null): void;
-    clearActivePosition(): void;
     setActiveTab(val: number): void;
     paneHeaderHeight: number;
     returnTab: number;
 }
 
 export const EventAddPanel: React.FC<EventAddPanelProps> = (
-    { setShowAddEventForm, activePosition, addEvent, clearActivePosition,
-        setActiveTab, paneHeaderHeight, activeLayer, layers, returnTab
+    { displayAddEventForm, activePosition, addEvent, setActiveTab,
+        paneHeaderHeight, activeLayer, layers, returnTab
     }: EventAddPanelProps) => {
 
     const [activeLayerTitle, setActiveLayerTitle] = useState<string>('');
@@ -56,16 +55,14 @@ export const EventAddPanel: React.FC<EventAddPanelProps> = (
             addEvent(
                 eventName === '' ? 'Untitled Marker' : eventName,
                 description, activePosition[0], activePosition[1], media);
-            setShowAddEventForm(false);
+            displayAddEventForm(false);
             setActiveTab(returnTab);
-            clearActivePosition();
         }
     };
 
     const handleCancel = (e: React.MouseEvent<HTMLButtonElement>): void => {
         e.preventDefault();
-        setShowAddEventForm(false);
-        clearActivePosition();
+        displayAddEventForm(false);
     };
 
     return (

--- a/media/src/project/project-map-pane.tsx
+++ b/media/src/project/project-map-pane.tsx
@@ -36,12 +36,11 @@ export interface ProjectMapPaneProps {
     updateLayer(pk: number, title: string): void;
     toggleLayerVisibility(pk: number): void;
     showAddEventForm: boolean;
-    setShowAddEventForm(val: boolean): void;
+    displayAddEventForm(show: boolean, mockData?: EventData): void;
     activePosition: Position | null;
     addEvent(label: string,
              description: string, lat: number, lng: number, mediaObj: MediaObject | null): void;
     deleteEvent(pk: number, layerPk: number): void;
-    clearActivePosition(): void;
     activeEvent: EventData | null;
     setActiveEvent(d: EventData): void;
     activeEventDetail: EventData | null;
@@ -59,10 +58,10 @@ export const ProjectMapPane = React.forwardRef<HTMLDivElement, ProjectMapPanePro
         updateProject, deleteProject, layers, layerVisibility, activity,
         createActivity, updateActivity, deleteActivity, activeLayer,
         setActiveLayer, addLayer, deleteLayer, updateLayer,
-        toggleLayerVisibility, showAddEventForm, setShowAddEventForm,
-        activePosition, addEvent, clearActivePosition, activeEvent,
-        setActiveEvent, activeEventDetail, setActiveEventDetail,
-        activeEventEdit, setActiveEventEdit, deleteEvent, updateEvent
+        toggleLayerVisibility, showAddEventForm, displayAddEventForm,
+        activePosition, addEvent, activeEvent, setActiveEvent,
+        activeEventDetail, setActiveEventDetail, activeEventEdit,
+        setActiveEventEdit, deleteEvent, updateEvent
     }: ProjectMapPaneProps, forwardedRef) => {
 
     const projectPaneHeader = useRef<HTMLDivElement>(null);
@@ -130,10 +129,9 @@ export const ProjectMapPane = React.forwardRef<HTMLDivElement, ProjectMapPanePro
     const PANEL: {[key: number]: ReactElement} = {
         0: <EventAddPanel
             showAddEventForm={showAddEventForm}
-            setShowAddEventForm={setShowAddEventForm}
+            displayAddEventForm={displayAddEventForm}
             activePosition={activePosition}
             addEvent={addEvent}
-            clearActivePosition={clearActivePosition}
             setActiveTab={setActiveTab}
             activeLayer={activeLayer}
             layers={layers}


### PR DESCRIPTION
This commit refactors DeckGL layer aggregation by having the components
re-initialize the layers on each render. Previously, the DeckGL layers
were being saved to state, which started to cause inconsistencies in how
they behaved, and which variables they would bind to. E.g. a value
passed in to the layer would be the value at the time of layer creation,
not the value at render-time.

This refactor then permitted the click handlers to bind to the correct
copy of the values.
