### PR TITLE
Feedback bug

### DIFF
--- a/media/src/activity/activity-map-pane-panels.tsx
+++ b/media/src/activity/activity-map-pane-panels.tsx
@@ -336,10 +336,16 @@ const FacultySubPanel: React.FC<FacultySubPanelProps> = ({
 
     useEffect(() => {
         // Populate feedback
-        if (activeResponse && activeResponse.feedback) {
-            setFeedback(activeResponse.feedback.body || '');
-            setFeedbackSubmittedDate(activeResponse.feedback.submitted_at_formatted || '');
-            setFeedbackModifiedDate(activeResponse.feedback.modified_at_formatted || '');
+        if (activeResponse) {
+            if (activeResponse.feedback) {
+                setFeedback(activeResponse.feedback.body);
+                setFeedbackSubmittedDate(activeResponse.feedback.submitted_at_formatted);
+                setFeedbackModifiedDate(activeResponse.feedback.modified_at_formatted);
+            } else {
+                setFeedback('');
+                setFeedbackSubmittedDate('');
+                setFeedbackModifiedDate('');
+            }
         }
 
         // Create a map of just the layers beloning to the active response
@@ -354,7 +360,7 @@ const FacultySubPanel: React.FC<FacultySubPanelProps> = ({
                 );
             }
         }
-    }, [activeResponse, responseData]);
+    }, [activeResponse]);
 
     const handleFeedbackSubmission = (e: React.FormEvent) => {
         e.preventDefault();

--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -42,7 +42,7 @@ interface FeedbackData {
     pk: number;
     body: string;
     submitted_at_formatted: string;
-    modified_at_formatted?: string;
+    modified_at_formatted: string;
     feedback_from: string;
 }
 


### PR DESCRIPTION
This commit fixes a bug where stale feedback would be displayed for an
author.
Steps:
- An author creates an activity
- Two or more collaborators submit a response
- The author submits feedback to one student
- Then author looks at another response and sees the same feedback in
  the text box.

This commit fixes the above bug by fixing the logic around how the
feedback text field is populated with each render.
