### PR TITLE
Filter workspaces based only on Course membership

### DIFF
--- a/locustempus/main/tests/test_utils.py
+++ b/locustempus/main/tests/test_utils.py
@@ -1,9 +1,14 @@
+from courseaffils.tests.factories import (
+    CourseFactory
+)
 from django.core import mail
 from django.test.testcases import TestCase
 from django.urls.base import reverse
 
 from locustempus.main.tests.factories import UserFactory
-from locustempus.main.utils import send_template_email
+from locustempus.main.utils import (
+    get_courses_for_user, get_courses_for_instructor, send_template_email
+)
 
 
 class UtilTest(TestCase):
@@ -23,3 +28,29 @@ class UtilTest(TestCase):
         with self.settings(SENTRY_DSN='foo'):
             r = self.client.get(reverse('index-view'))
             self.assertEqual('foo', r.context['SENTRY_DSN'])
+
+    def test_get_courses(self):
+        course = CourseFactory()
+        student = UserFactory()
+        instructor = UserFactory()
+
+        course.group.user_set.add(student)
+        course.group.user_set.add(instructor)
+        course.faculty_group.user_set.add(instructor)
+
+        # as student
+        lst = get_courses_for_user(student)
+        self.assertEquals(len(lst), 1)
+        self.assertTrue(course in lst)
+
+        lst = get_courses_for_instructor(student)
+        self.assertEquals(len(lst), 0)
+
+        # as instructor
+        lst = get_courses_for_user(instructor)
+        self.assertEquals(len(lst), 1)
+        self.assertTrue(course in lst)
+
+        lst = get_courses_for_instructor(instructor)
+        self.assertEquals(len(lst), 1)
+        self.assertTrue(course in lst)

--- a/locustempus/main/utils.py
+++ b/locustempus/main/utils.py
@@ -1,4 +1,5 @@
 """Locus Tempus Utility Functions"""
+from courseaffils.models import Course
 from django.conf import settings
 from django.core.mail import send_mail
 from django.core.validators import validate_email
@@ -15,3 +16,21 @@ def send_template_email(subject: str, template_name: str,
     template = loader.get_template(template_name)
     message = template.render(context)
     send_mail(subject, message, settings.SERVER_EMAIL, [recipient])
+
+
+def get_courses_for_user(user):
+    courses = Course.objects.none()
+    if not user.is_anonymous:
+        courses = Course.objects.filter(group__user=user)
+    return courses.order_by('-info__year', '-info__term', 'title')
+
+
+def get_courses_for_instructor(user):
+    courses = Course.objects.none()
+    if not user.is_anonymous:
+        courses = Course.objects.filter(faculty_group__user=user)
+
+    courses = courses.order_by('-info__year', '-info__term', 'title')
+    return courses.select_related(
+            'info', 'group', 'faculty_group', 'settings').prefetch_related(
+                'coursedetails_set')

--- a/locustempus/main/views.py
+++ b/locustempus/main/views.py
@@ -2,7 +2,6 @@ import re
 
 from courseaffils.columbia import WindTemplate, CanvasTemplate
 from courseaffils.models import Course
-from courseaffils.views import get_courses_for_user
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import (
@@ -34,7 +33,7 @@ from locustempus.main.models import GuestUserAffil, Project, Response
 from locustempus.main.management.commands.integrationserver import (
     reset_test_models
 )
-from locustempus.main.utils import send_template_email
+from locustempus.main.utils import get_courses_for_user, send_template_email
 from locustempus.mixins import (
     LoggedInCourseMixin, LoggedInFacultyMixin
 )

--- a/locustempus/main/viewsets.py
+++ b/locustempus/main/viewsets.py
@@ -1,5 +1,4 @@
 """The viewsets and views used for the API"""
-from courseaffils.views import get_courses_for_user, get_courses_for_instructor
 from django.db.models import Q, Exists, OuterRef
 from locustempus.main.models import (
     Layer, Project, Event, Activity, Response, Feedback
@@ -11,6 +10,9 @@ from locustempus.main.permissions import (
 from locustempus.main.serializers import (
     LayerSerializer, ProjectSerializer, EventSerializer, ActivitySerializer,
     ResponseSerializer, FeedbackSerializer
+)
+from locustempus.main.utils import (
+    get_courses_for_user, get_courses_for_instructor
 )
 from rest_framework.viewsets import ModelViewSet
 


### PR DESCRIPTION
This commit re-implements the `get_courses_for_user` and
`get_courses_for_instructor` library methods such that the
courses that are returned relate to the user only by course membership.
Staff users will no longer see all courses on the dashboard.

This fixes issues where users could see a course as a staff user, but could
not see related projects.
