### PR TITLE
Clear results

### DIFF
--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -692,6 +692,18 @@ export const ActivityMap: React.FC = () => {
         (newViewport: React.SetStateAction<ViewportState>) => setViewportState(newViewport),
         []
     );
+    const handleGeocoderViewportChange = useCallback(
+        (newViewport) => {
+            const geocoderDefaultOverrides = { transitionDuration: 1000 };
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            return handleViewportChange({
+                ...newViewport,
+                ...geocoderDefaultOverrides
+            });
+        },
+        [handleViewportChange]
+    );
 
     useEffect(() => {
         // TODO: Refactor this to rededuce complexity
@@ -919,7 +931,7 @@ export const ActivityMap: React.FC = () => {
                                     onResult={(res: Results) => {
                                         handleSearch(res);
                                     }}
-                                    onViewportChange={handleViewportChange}>
+                                    onViewportChange={handleGeocoderViewportChange}>
                                 </Geocoder>
                             }
                         </StaticMap>

--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -26,7 +26,7 @@ import {
     ICON_ATLAS, ICON_MAPPING, ICON_SCALE, ICON_SIZE, ICON_SIZE_ACTIVE,
     ICON_COLOR, ICON_COLOR_ACTIVE, ICON_COLOR_NEW_EVENT,
     DEFAULT_VIEWPORT_STATE, ViewportState, ProjectData, DeckGLClickEvent,
-    LayerData, EventData, MediaObject, TileSublayerProps, Results
+    LayerData, EventData, MediaObject, TileSublayerProps, Result
 } from '../project-activity-components/common';
 
 export interface ActivityData {
@@ -145,7 +145,7 @@ export const ActivityMap: React.FC = () => {
     const geocoderContainerRef = useRef<HTMLDivElement>(null);
 
     const [showSearchPopup, setShowSearchPopup] = useState<boolean>(false);
-    const [searchResult, setSearchResult] = useState<Results | null>(null);
+    const [searchResult, setSearchResult] = useState<Result | null>(null);
 
     useEffect(() => {
         if (alertString) {
@@ -618,10 +618,10 @@ export const ActivityMap: React.FC = () => {
         displayAddEventForm(true, mockData);
     };
 
-    const handleSearch = (results: Results) => {
-        setSearchResult(results);
+    const handleSearch = useCallback((result: Result) => {
+        setSearchResult(result);
         setShowSearchPopup(true);
-    };
+    }, []);
 
     const pickEventClickHandler = (info: PickInfo<EventData>): boolean => {
         if (showAddEventForm || activeEventEdit) {
@@ -927,10 +927,7 @@ export const ActivityMap: React.FC = () => {
                                     reverseGeocode={true}
                                     minLength={4}
                                     enableEventLogging={false}
-                                    clearAndBlurOnEsc={true}
-                                    onResult={(res: Results) => {
-                                        handleSearch(res);
-                                    }}
+                                    onResult={handleSearch}
                                     onViewportChange={handleGeocoderViewportChange}>
                                 </Geocoder>
                             }

--- a/media/src/project-activity-components/common.tsx
+++ b/media/src/project-activity-components/common.tsx
@@ -139,7 +139,7 @@ export interface Context {
     text: string;
 }
 
-export interface Results {
+export interface Result {
     result: {
         center: [number, number];
         context: [Context];

--- a/media/src/project/project-map.tsx
+++ b/media/src/project/project-map.tsx
@@ -17,7 +17,7 @@ import {
     ICON_ATLAS, ICON_MAPPING, ICON_SCALE, ICON_SIZE, ICON_SIZE_ACTIVE,
     ICON_COLOR, ICON_COLOR_ACTIVE, ICON_COLOR_NEW_EVENT,
     DEFAULT_VIEWPORT_STATE, ViewportState, ProjectData, ActivityData,
-    LayerData, EventData, MediaObject, DeckGLClickEvent, TileSublayerProps, Results
+    LayerData, EventData, MediaObject, DeckGLClickEvent, TileSublayerProps, Result
 } from '../project-activity-components/common';
 
 import {get, put, post, del, getBoundedViewport } from '../utils';
@@ -77,7 +77,7 @@ export const ProjectMap: React.FC = () => {
     const geocoderContainerRef = useRef<HTMLDivElement>(null);
 
     const [showSearchPopup, setShowSearchPopup] = useState<boolean>(false);
-    const [searchResult, setSearchResult] = useState<Results | null>(null);
+    const [searchResult, setSearchResult] = useState<Result | null>(null);
 
     const setBaseMap = (baseMap: string) => {
         if (projectData) {
@@ -383,10 +383,10 @@ export const ProjectMap: React.FC = () => {
         displayAddEventForm(true, mockData);
     };
 
-    const handleSearch = (results: Results) => {
-        setSearchResult(results);
+    const handleSearch = useCallback((result: Result) => {
+        setSearchResult(result);
         setShowSearchPopup(true);
-    };
+    }, []);
 
     const pickEventClickHandler = (info: PickInfo<EventData>): boolean => {
         if (showAddEventForm || activeEventEdit) {
@@ -572,10 +572,7 @@ export const ProjectMap: React.FC = () => {
                                     reverseGeocode={true}
                                     minLength={4}
                                     enableEventLogging={false}
-                                    clearAndBlurOnEsc={true}
-                                    onResult={(res: Results) => {
-                                        handleSearch(res);
-                                    }}
+                                    onResult={handleSearch}
                                     onViewportChange={handleGeocoderViewportChange}>
                                 </Geocoder>
                             }

--- a/media/src/project/project-map.tsx
+++ b/media/src/project/project-map.tsx
@@ -447,6 +447,18 @@ export const ProjectMap: React.FC = () => {
         (newViewport: React.SetStateAction<ViewportState>) => setViewportState(newViewport),
         []
     );
+    const handleGeocoderViewportChange = useCallback(
+        (newViewport) => {
+            const geocoderDefaultOverrides = { transitionDuration: 1000 };
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            return handleViewportChange({
+                ...newViewport,
+                ...geocoderDefaultOverrides
+            });
+        },
+        [handleViewportChange]
+    );
 
     useEffect(() => {
         const getData = async(): Promise<void> => {
@@ -564,7 +576,7 @@ export const ProjectMap: React.FC = () => {
                                     onResult={(res: Results) => {
                                         handleSearch(res);
                                     }}
-                                    onViewportChange={handleViewportChange}>
+                                    onViewportChange={handleGeocoderViewportChange}>
                                 </Geocoder>
                             }
                         </StaticMap>


### PR DESCRIPTION
* speed up transition
* memoizing the handlesearch functions. this fixes the messiness left over when it was creating a new function at render
* rename results to result since we're only dealing with the final result here