### PR TITLE
update django-s3sign --> v0.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=3.2.14,<4
 asgiref==3.5.1
-django-s3sign==0.2.1
+django-s3sign==0.3.2
 pytz==2022.6
 httplib2==0.21.0
 feedparser==6.0.8


### PR DESCRIPTION
It seems to be running well here, or as well as the previous version did.