### PR TITLE
Make addEvent code more clear

### DIFF
--- a/media/src/activity/activity-map.tsx
+++ b/media/src/activity/activity-map.tsx
@@ -397,7 +397,7 @@ export const ActivityMap: React.FC = () => {
         // Check if the current user can add an event to the current active layer
         // If faculty and the active layer is not a project layer, use the first project layer
         // If student and the active layer is not in layerData, is the first layer in layerData
-        if (!activeLayer) {
+        if (activeLayer === null) {
             throw new Error('Add Event failed: no active layer is defined');
         }
         let layerPk = activeLayer;
@@ -431,26 +431,30 @@ export const ActivityMap: React.FC = () => {
             media: mediaObj ? [mediaObj] : null
         };
         void post<EventData>('/api/event/', data)
-            .then((data) => {
-                if (layerPk) {
+            .then((d) => {
+                if (layerPk !== null) {
                     const updatedLayers = new Map(isFaculty ? projectLayerData : layerData);
                     const layer = updatedLayers.get(layerPk);
 
                     if (layer) {
                         const updatedLayer = {
                             ...layer,
-                            events: [...layer.events, data]
+                            events: [...layer.events, d]
                         };
                         updatedLayers.set(layerPk, updatedLayer);
 
                         const setLayerDataFunc = isFaculty ? setProjectLayerData : setLayerData;
                         setLayerDataFunc(updatedLayers);
 
-                        setActiveEvent(data);
-                        goToEvent(data);
+                        setActiveEvent(d);
+                        goToEvent(d);
                     } else {
-                        throw new Error('Add Event failed: the active layer failed to be located');
+                        throw new Error(
+                            'Activity addEvent failed: ' +
+                                'the active layer failed to be located');
                     }
+                } else {
+                    throw new Error('Activity addEvent failed: no layerPk');
                 }
             });
     };

--- a/media/src/project/project-map.tsx
+++ b/media/src/project/project-map.tsx
@@ -217,7 +217,7 @@ export const ProjectMap: React.FC = () => {
     const addEvent = (
         label: string, description: string, lat: number, lng: number,
         mediaObj: MediaObject | null): void => {
-        if (!activeLayer) {
+        if (activeLayer === null) {
             throw new Error('Add Event failed: no active layer is defined');
         }
         const data = {
@@ -232,24 +232,25 @@ export const ProjectMap: React.FC = () => {
             media: mediaObj ? [mediaObj] : null
         };
         void post<EventData>('/api/event/', data)
-            .then((data) => {
-                if (activeLayer) {
+            .then((d) => {
+                if (activeLayer !== null) {
                     const updatedLayers = new Map(layerData);
                     const layer = layerData.get(activeLayer);
 
                     if (layer) {
                         const updatedLayer = {
                             ...layer,
-                            events: [...layer.events].concat(data)
+                            events: [...layer.events].concat(d)
                         };
                         updatedLayers.set(activeLayer, updatedLayer);
 
                         setLayerData(updatedLayers);
-                        setActiveEvent(data);
-                        goToEvent(data);
+                        setActiveEvent(d);
+                        goToEvent(d);
                     }
                 } else {
-                    throw new Error('No active layer present.');
+                    throw new Error(
+                        'Project addEvent failed: No active layer present.');
                 }
             });
     };


### PR DESCRIPTION
* Throw an error in activity when layerPk is missing
* Fix scope overlap: the `data` variable is already in scope as a const, use `d` for the data returned from the xhr call.

Also, be slightly more lenient about activeLayer/layerPk when expecting
a number: this number can be 0, maybe that is a valid layerPk. Only fail
on null.