### PR TITLE
when tab is clicked go back to responses

### DIFF
--- a/media/src/activity/activity-map-pane-panels.tsx
+++ b/media/src/activity/activity-map-pane-panels.tsx
@@ -101,6 +101,7 @@ export const DefaultPanel: React.FC<DefaultPanelProps> = (
         e: React.MouseEvent<HTMLAnchorElement>): void => {
         e.preventDefault();
         setActiveTab(Number(e.currentTarget.dataset.activeTab));
+        setActiveResponse(null);
     };
 
     const handleSubmitResponse = (e: React.FormEvent<HTMLFormElement>): void => {


### PR DESCRIPTION
* sets the active response back to null when the Response tab is clicked. This will lead back to the response list