### PR TITLE
Add missing CASMiddleware

### DIFF
--- a/locustempus/settings_shared.py
+++ b/locustempus/settings_shared.py
@@ -51,6 +51,7 @@ INSTALLED_APPS += [  # noqa
 
 MIDDLEWARE += [ # noqa
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django_cas_ng.middleware.CASMiddleware',
     'locustempus.main.middleware.WhoDidItMiddleware',
 ]
 


### PR DESCRIPTION
It looks like django-cas was working fine without this, but CASMiddleware is supposed to be active here. It looks like it helps with some redirect logic in certain cases.

https://djangocas.dev/docs/latest/_modules/django_cas_ng/middleware.html