### PR TITLE
Remove unused django-jenkins package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,6 @@ django-statsd-mozilla==0.4.0
 django-bootstrap4==23.2
 django-debug-toolbar==4.1.0
 django-waffle==4.0.0
-django-jenkins==0.110.0
 django-smoketest==1.2.0
 sentry-sdk==1.29.0
 django-extensions==3.2.0


### PR DESCRIPTION
This package was getting included, even though the `django_jenkins` django app wasn't even being enabled in this project. So, it can be removed.