### PR TITLE
Remove cypress from jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP=locustempus
 JS_FILES=media/src
 
-all: jenkins js-typecheck cypress-test
+all: jenkins
 .PHONY: all
 
 include *.mk


### PR DESCRIPTION
Js-typecheck runs with github actions so I think we can remove it from jenkins